### PR TITLE
Add config, docs for Emacs/Cider users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Clone this repo, enter the directory. Then install prerequisites:
 
 Compile the ClojureScript code and start a server for the UI:
 
-    clojure -M:serve
+    clojure -M:serve 
+    # or, if using Emacs or needing Cider for some other reason:
+    # clojure -M:cider:serve
 
 You can now see the application at http://localhost:8000. Open it in Chrome, where you have [installed Fulcro Inspect](https://book.fulcrologic.com/#_install_fulcro_inspect) and [enabled custom formatters](https://book.fulcrologic.com/#_configure_chrome_development_settings)!
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,4 +5,7 @@
  :aliases
  {:serve {:main-opts ["-m" "shadow.cljs.devtools.cli" "watch" "main"]
           :extra-deps {thheller/shadow-cljs                {:mvn/version "2.11.6"}
-                       binaryage/devtools                  {:mvn/version "1.0.0"}}}}}
+                       binaryage/devtools                  {:mvn/version "1.0.0"}}}
+  ;; Activate if you want to `M-x cider-connect-cljs` from Emacs:
+  :cider {:extra-deps {cider/cider-nrepl {:mvn/version "0.25.9"}           ; must be added for M-x cider-connect-cljs
+                       cider/piggieback {:mvn/version "0.5.1"}}}}}


### PR DESCRIPTION
Reportedly, Emacs users need this for `M-x cider-connect-cljs` to work.