### PR TITLE
Make it easier to use Calva with this project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ node_modules
 .shadow-cljs/
 resources/public/js
 resources/public/workspaces/js
-.lsp
+.lsp/sqlite.db
 lsp

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ resources/public/js
 resources/public/workspaces/js
 .lsp/sqlite.db
 lsp
+.calva/output-window/output.calva-repl

--- a/deps.edn
+++ b/deps.edn
@@ -3,9 +3,10 @@
         com.fulcrologic/fulcro {:mvn/version "3.4.22"}
         com.wsscode/pathom     {:mvn/version "2.3.1"}}
  :aliases
- {:serve {:jvm-opts    ["-XX:-OmitStackTraceInFastThrow"]
+ {:shadow-cljs {:extra-deps {thheller/shadow-cljs {:mvn/version "2.15.5"}}}
+  :serve {:jvm-opts    ["-XX:-OmitStackTraceInFastThrow"]
           :main-opts ["-m" "shadow.cljs.devtools.cli" "watch" "main"]
-          :extra-deps {thheller/shadow-cljs                {:mvn/version "2.11.6"}
+          :extra-deps {thheller/shadow-cljs                {:mvn/version "2.15.5"}
                        binaryage/devtools                  {:mvn/version "1.0.0"}}}
   ;; Activate if you want to `M-x cider-connect-cljs` from Emacs:
   :cider {:extra-deps {cider/cider-nrepl {:mvn/version "0.25.9"}           ; must be added for M-x cider-connect-cljs
@@ -13,8 +14,8 @@
 
   :serve-puzzles {:jvm-opts    ["-XX:-OmitStackTraceInFastThrow"]
                   :main-opts ["-m" "shadow.cljs.devtools.cli" "watch" "workspaces"]
-                  :extra-deps {thheller/shadow-cljs                {:mvn/version "2.11.6"}
+                  :extra-deps {thheller/shadow-cljs                {:mvn/version "2.15.5"}
                                binaryage/devtools                  {:mvn/version "1.0.0"}
                                ;; for Workspaces:
-                               ;com.github.awkay/workspaces {:mvn/version "1.0.2"}
-                               com.github.awkay/workspaces {:local/root "/Users/holyjak/tmp/delme/workspaces"}}}}}
+                               com.github.awkay/workspaces {:mvn/version "1.0.2"}
+                               #_#_com.github.awkay/workspaces {:local/root "/Users/holyjak/tmp/delme/workspaces"}}}}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -826,9 +826,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.15.2.tgz",
-      "integrity": "sha512-WPlSMkGgbU5b2nrt+Y1A1TsPs5Rip/JvCxGG2t2Pvzo+pLJ+RcpkZgAxjNQNNA7VYWEh5Pqwyvq5KzQ+0LMsxw==",
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.15.5.tgz",
+      "integrity": "sha512-RTiQjmjfDUrMMjs5McpW8GTCcmtsaVs84v+YmzTNDB6dhvqtu/F+p//cd218p1h+TcP8gY6zeA/9sjh6mHaYJQ==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "react-grid-layout": "^0.16.6"
   },
   "devDependencies": {
-    "shadow-cljs": "^2.15.2"
+    "shadow-cljs": "^2.15.5"
   }
 }


### PR DESCRIPTION
Calva Jack-in can't really handle the aliases with main functions defined, because Calva provides it's own main option starting the the nrepl server. So I added an alias which provides only the shadow-cljs dependency, which user then can select for Calva jack-in.

I also bumped and synchronized shadow-cljs version across package.json and deps.edn. Let me know if you don't like to have that in the same PR and I can provide a cleaner one.